### PR TITLE
Div 2000 logout

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This module exposes three middleware functions that take in an object parameter.
 * **authenticate** - checks if the current user has a valid auth token cookie, if not redirects them to the idam login page with a query parameter `args.continueUrl` to determine where the user will be sent on successful login
 * **landingPage** - should only run on the page that idam redirects to after successful authentication. This sets auth token cookie based on the jwt query parameter passed back by idam
 * **protect** - checks if the user has a valid auth token cookie, and makes sure it matches against the current session user details. If not, this redirects them to a page defined by the user `args.indexUrl`
+* **logout** - This makes a request to idam to invalidate the session Jwt token on exit/logout. It provides the jwt token to idam as a path parameter in the http request url.
 
 
 ##  Arguments

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Until then, the package can be installed from its github URL, examples:
 yarn add https://github.com/hmcts/div-idam-express-middleware
 
 # Install a specific version
-yarn add https://github.com/hmcts/div-idam-express-middleware#3.0.4
+yarn add https://github.com/hmcts/div-idam-express-middleware#3.0.5
 ```
 
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const idamExpressAuthenticate = require('./services/idamExpressAuthenticate');
 const idamExpressLanding = require('./services/idamExpressLanding');
 const idamExpressProtect = require('./services/idamExpressProtect');
+const idamExpressLogout = require('./services/idamExpressLogout');
 
 const authenticate = (args = {}) => {
   return idamExpressAuthenticate(args);
@@ -14,4 +15,8 @@ const protect = (args = {}) => {
   return idamExpressProtect(args);
 };
 
-module.exports = { authenticate, landingPage, protect };
+const logout = (args = {}) => {
+  return idamExpressLogout(args);
+};
+
+module.exports = { authenticate, landingPage, protect, logout };

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "posttest-coverage": "istanbul check-coverage --statements 80 --branches 80 --functions 80 --lines 80",
     "test-nsp": "yarn nsp check",
     "test": "yarn lint && yarn test-coverage && yarn test-nsp",
+    "test-unit": "NODE_PATH=. mocha services/*.test.js utilities/*.test.js wrapper/*.test.js --reporter spec --recursive -t 3000",
     "sonar-scanner": "node_modules/sonar-scanner/bin/sonar-scanner"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/div-idam-express-middleware",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "Express middleware for IDAM integration",
   "license": "MIT",
   "main": "index.js",

--- a/services/idamExpressLogout.js
+++ b/services/idamExpressLogout.js
@@ -12,26 +12,19 @@ const idamExpressLogout = (args = {}) => {
   const tokenCookieName = args.tokenCookieName || config.tokenCookieName;
 
   return (req, res, next) => {
-
     const authToken = cookies.get(req, tokenCookieName);
-
     const logoutUrl = `${idamFunctions.getIdamApiUrl()}/session/${authToken}`;
 
-    const options = {
-      method: 'DELETE',
-      uri: logoutUrl,
-    };
-
-    request(options)
-    .then(function (response) {
-      logger.info(`Token successfully deleted`);
-      next();
-    })
-    .catch(function (err) {
-      logger.error(`Token deletion failed with error ${err}`);
-      next();
-    });
-  }
+    return request.delete(logoutUrl)
+      .then(() => {
+        logger.info('Token successfully deleted');
+        next();
+      })
+      .catch(error => {
+        logger.error(`Token deletion failed with error ${error}`);
+        next();
+      });
+  };
 };
 
 module.exports = idamExpressLogout;

--- a/services/idamExpressLogout.js
+++ b/services/idamExpressLogout.js
@@ -1,0 +1,37 @@
+const idamWrapper = require('../wrapper');
+const { Logger } = require('@hmcts/nodejs-logging');
+const request = require('request-promise-native');
+const cookies = require('../utilities/cookies');
+const config = require('../config');
+
+const logger = Logger.getLogger(__filename);
+
+const idamExpressLogout = (args = {}) => {
+  const idamFunctions = idamWrapper.setup(args);
+
+  const tokenCookieName = args.tokenCookieName || config.tokenCookieName;
+
+  return (req, res, next) => {
+
+    const authToken = cookies.get(req, tokenCookieName);
+
+    const logoutUrl = `${idamFunctions.getIdamApiUrl()}/session/${authToken}`;
+
+    const options = {
+      method: 'DELETE',
+      uri: logoutUrl,
+    };
+
+    request(options)
+    .then(function (response) {
+      logger.info(`Token successfully deleted`);
+      next();
+    })
+    .catch(function (err) {
+      logger.error(`Token deletion failed with error ${err}`);
+      next();
+    });
+  }
+};
+
+module.exports = idamExpressLogout;

--- a/services/idamExpressLogout.test.js
+++ b/services/idamExpressLogout.test.js
@@ -1,0 +1,70 @@
+const sinon = require('sinon');
+const { expect } = require('chai');
+const idamWrapper = require('../wrapper');
+const middleware = require('./idamExpressAuthenticate');
+const sinonStubPromise = require('sinon-stub-promise');
+
+sinonStubPromise(sinon);
+
+let req = null;
+let res = null;
+let next = null;
+const idamArgs = {};
+
+describe('idamExpressLogout', () => {
+  it('should return a middleware handler', () => {
+    const handler = middleware();
+    expect(handler).to.be.a('function');
+  });
+
+  describe('middleware', () => {
+    beforeEach(() => {
+      req = { cookies: {} };
+      res = {
+        redirect: sinon.stub(),
+        cookie: sinon.stub(),
+        clearCookie: sinon.stub()
+      };
+      next = sinon.stub();
+    });
+
+    {
+      let getIdamApiUrl = null;
+      let idamExpressLogout = null;
+
+      beforeEach(() => {
+
+        getIdamApiUrl = sinon.stub().returns('/');
+        sinon.stub(idamWrapper, 'setup').returns({ getIdamApiUrl });
+        idamExpressLogout = middleware(idamArgs);
+      });
+
+      afterEach(() => {
+        idamWrapper.setup.restore();
+      });
+
+      describe('no auth token', () => {
+        it('should call getIdamApiUrl', () => {
+          idamExpressLogout(req, res, next);
+
+          expect(getIdamApiUrl.callCount).to.equal(1);
+          expect(res.cookie.callCount).to.equal(1);
+        });
+      });
+      describe('with auth token', () => {
+        beforeEach(() => {
+          req = { cookies: { '__auth-token': 'token' } };
+        });
+
+
+        it('should call next if getIdamLoginUrl if getUserDetails rejects', () => {
+          idamExpressLogout(req, res, next);
+
+          expect(getIdamApiUrl.callCount).to.equal(1);
+          expect(res.cookie.callCount).to.equal(1);
+        });
+      });
+    }
+
+  });
+});

--- a/wrapper/index.js
+++ b/wrapper/index.js
@@ -7,7 +7,7 @@ const setup = (args = {}) => {
     return loginUrl(options, args);
   };
   const getIdamApiUrl = options => {
-    return args.logoutUrl;
+    return args.idamApiUrl;
   };
 
   const getUserDetails = authToken => {

--- a/wrapper/index.js
+++ b/wrapper/index.js
@@ -6,7 +6,7 @@ const setup = (args = {}) => {
   const getIdamLoginUrl = options => {
     return loginUrl(options, args);
   };
-  const getIdamApiUrl = options => {
+  const getIdamApiUrl = () => {
     return args.idamApiUrl;
   };
 

--- a/wrapper/index.js
+++ b/wrapper/index.js
@@ -6,6 +6,9 @@ const setup = (args = {}) => {
   const getIdamLoginUrl = options => {
     return loginUrl(options, args);
   };
+  const getIdamApiUrl = options => {
+    return args.logoutUrl;
+  };
 
   const getUserDetails = authToken => {
     return userDetails(authToken, args);
@@ -15,7 +18,7 @@ const setup = (args = {}) => {
     return accessToken(options, args);
   };
 
-  return { getIdamLoginUrl, getUserDetails, getAccessToken };
+  return { getIdamLoginUrl, getUserDetails, getAccessToken, getIdamApiUrl };
 };
 
 module.exports = { setup };


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DIV-2000

Add Login functionality to the divorce application on save&close, exit and done.

This is the logout middleware required by the frontend to call idam delete session API.
A class called idamExpressLogout has been added.
A corresponding unit test has also been added.
