### PR TITLE
update nsp, fix get cookies if cookies not defined, refactor remove cookie on logout

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,7 +1,7 @@
 {
   "exceptions": [
-  	"https://nodesecurity.io/advisories/534",
-  	"https://nodesecurity.io/advisories/533",
-    "https://nodesecurity.io/advisories/566"
+  	"https://nodesecurity.io/advisories/598",
+  	"https://nodesecurity.io/advisories/566",
+    "https://nodesecurity.io/advisories/533"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/div-idam-express-middleware",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "Express middleware for IDAM integration",
   "license": "MIT",
   "main": "index.js",

--- a/services/idamExpressLogout.js
+++ b/services/idamExpressLogout.js
@@ -19,7 +19,7 @@ const idamExpressLogout = (args = {}) => {
       .then(() => {
         logger.info('Token successfully deleted');
         // if logout is successfull remove token cookie
-        res.clearCookie(tokenCookieName);
+        cookies.remove(res, tokenCookieName);
         next();
       })
       .catch(error => {

--- a/services/idamExpressLogout.test.js
+++ b/services/idamExpressLogout.test.js
@@ -23,7 +23,7 @@ describe('idamExpressLogout', () => {
   describe('middleware', () => {
     beforeEach(() => {
       req = { cookies: {} };
-      res = { cookie: sinon.stub(), clearCookie: sinon.stub() };
+      res = { cookie: sinon.stub() };
       next = sinon.stub();
 
       const idamFUnctionsStub = {
@@ -32,11 +32,13 @@ describe('idamExpressLogout', () => {
       };
       sinon.stub(idamWrapper, 'setup').returns(idamFUnctionsStub);
       sinon.stub(cookies, 'get').returns(authToken);
+      sinon.stub(cookies, 'remove').returns(authToken);
       sinon.stub(request, 'delete');
     });
 
     afterEach(() => {
       cookies.get.restore();
+      cookies.remove.restore();
       idamWrapper.setup.restore();
       request.delete.restore();
     });
@@ -54,7 +56,7 @@ describe('idamExpressLogout', () => {
           expect(cookies.get.calledOnce).to.eql(true);
           expect(request.delete.calledOnce).to.eql(true);
           expect(request.delete.calledWith(logoutUrl)).to.eql(true);
-          expect(res.clearCookie.calledOnce).to.eql(true);
+          expect(cookies.remove.calledOnce).to.eql(true);
         })
         .then(done, done);
     });

--- a/utilities/cookies.js
+++ b/utilities/cookies.js
@@ -8,7 +8,10 @@ const set = (res, cookieName, cookieValue,
 };
 
 const get = (req, cookieName) => {
-  return req.cookies[cookieName];
+  if (req.cookies) {
+    return req.cookies[cookieName];
+  }
+  return undefined; // eslint-disable-line no-undefined
 };
 
 const remove = (res, cookieName) => {

--- a/utilities/cookies.test.js
+++ b/utilities/cookies.test.js
@@ -50,6 +50,15 @@ describe('cookies', () => {
       // Assert.
       expect(output).to.equal(undefined); // eslint-disable-line no-undefined
     });
+
+    it('returns undefined when no cookies set', () => {
+      // Arrange.
+      delete req.cookies;
+      // Act.
+      const output = cookies.get(req, 'nonexistent-cookie');
+      // Assert.
+      expect(output).to.equal(undefined); // eslint-disable-line no-undefined
+    });
   });
 
   describe('#remove', () => {


### PR DESCRIPTION
#### Change description

Removes the stale cookie once logged out from idam. This helps fix [DIV-2498 - Error decrypting Redis when logging on](https://tools.hmcts.net/jira/browse/DIV-2498)

Also:
 - Refactors remove cookie to use utils
 - Adds catch if cookies not defined on req
 - Updates nsp's

#### Work checklist

- [x] Commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added if needed
- [x] Tests have been updated / new tests has been added if needed
