### PR TITLE
Adapt logout for oauth2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/div-idam-express-middleware",
-  "version": "6.0.2",
+  "version": "6.1.0",
   "description": "Express middleware for IDAM integration",
   "license": "MIT",
   "main": "index.js",

--- a/services/idamExpressLogout.js
+++ b/services/idamExpressLogout.js
@@ -14,8 +14,12 @@ const idamExpressLogout = (args = {}) => {
   return (req, res, next) => {
     const authToken = cookies.get(req, tokenCookieName);
     const logoutUrl = `${idamFunctions.getIdamApiUrl()}/session/${authToken}`;
+    const options = {
+      uri: logoutUrl,
+      headers: { Authorization: idamFunctions.getServiceAuth() }
+    };
 
-    return request.delete(logoutUrl)
+    return request.delete(options)
       .then(() => {
         logger.info('Token successfully deleted');
         // if logout is successfull remove token cookie

--- a/services/idamExpressLogout.js
+++ b/services/idamExpressLogout.js
@@ -16,7 +16,10 @@ const idamExpressLogout = (args = {}) => {
     const logoutUrl = `${idamFunctions.getIdamApiUrl()}/session/${authToken}`;
     const options = {
       uri: logoutUrl,
-      headers: { Authorization: idamFunctions.getServiceAuth() }
+      headers: {
+        Authorization: idamFunctions.getServiceAuth(),
+        'Content-Type': 'application/x-www-form-urlencoded'
+      }
     };
 
     return request.delete(options)

--- a/services/idamExpressLogout.test.js
+++ b/services/idamExpressLogout.test.js
@@ -17,7 +17,10 @@ const logoutUrl = `${idamApiUrl}/session/${authToken}`;
 const serviceAuth = 'base64String';
 const options = {
   uri: logoutUrl,
-  headers: { Authorization: serviceAuth }
+  headers: {
+    Authorization: serviceAuth,
+    'Content-Type': 'application/x-www-form-urlencoded'
+  }
 };
 describe('idamExpressLogout', () => {
   it('should return a middleware handler', () => {

--- a/services/idamExpressLogout.test.js
+++ b/services/idamExpressLogout.test.js
@@ -14,6 +14,11 @@ let next = null;
 const idamApiUrl = '/idamApiUrl';
 const authToken = 'token';
 const logoutUrl = `${idamApiUrl}/session/${authToken}`;
+const serviceAuth = 'base64String';
+const options = {
+  uri: logoutUrl,
+  headers: { Authorization: serviceAuth }
+};
 describe('idamExpressLogout', () => {
   it('should return a middleware handler', () => {
     const handler = middleware();
@@ -26,11 +31,13 @@ describe('idamExpressLogout', () => {
       res = { cookie: sinon.stub() };
       next = sinon.stub();
 
-      const idamFUnctionsStub = {
+      const idamFunctionsStub = {
         getIdamApiUrl: sinon.stub()
-          .returns(idamApiUrl)
+          .returns(idamApiUrl),
+        getServiceAuth: sinon.stub()
+          .returns(serviceAuth)
       };
-      sinon.stub(idamWrapper, 'setup').returns(idamFUnctionsStub);
+      sinon.stub(idamWrapper, 'setup').returns(idamFunctionsStub);
       sinon.stub(cookies, 'get').returns(authToken);
       sinon.stub(cookies, 'remove').returns(authToken);
       sinon.stub(request, 'delete');
@@ -55,7 +62,7 @@ describe('idamExpressLogout', () => {
           expect(idamWrapper.setup.calledOnce).to.eql(true);
           expect(cookies.get.calledOnce).to.eql(true);
           expect(request.delete.calledOnce).to.eql(true);
-          expect(request.delete.calledWith(logoutUrl)).to.eql(true);
+          expect(request.delete.calledWith(options)).to.eql(true);
           expect(cookies.remove.calledOnce).to.eql(true);
         })
         .then(done, done);
@@ -72,7 +79,7 @@ describe('idamExpressLogout', () => {
           expect(idamWrapper.setup.calledOnce).to.eql(true);
           expect(cookies.get.calledOnce).to.eql(true);
           expect(request.delete.calledOnce).to.eql(true);
-          expect(request.delete.calledWith(logoutUrl)).to.eql(true);
+          expect(request.delete.calledWith(options)).to.eql(true);
         })
         .then(done, done);
     });

--- a/wrapper/index.js
+++ b/wrapper/index.js
@@ -6,6 +6,7 @@ const setup = (args = {}) => {
   const getIdamLoginUrl = options => {
     return loginUrl(options, args);
   };
+
   const getIdamApiUrl = () => {
     return args.idamApiUrl;
   };
@@ -18,7 +19,17 @@ const setup = (args = {}) => {
     return accessToken(options, args);
   };
 
-  return { getIdamLoginUrl, getUserDetails, getAccessToken, getIdamApiUrl };
+  const getServiceAuth = () => {
+    return args.serviceAuth;
+  };
+
+  return {
+    getIdamLoginUrl,
+    getUserDetails,
+    getAccessToken,
+    getIdamApiUrl,
+    getServiceAuth
+  };
 };
 
 module.exports = { setup };


### PR DESCRIPTION
SIDAM Oauth2 Logout requires the Service to pass their client name and secret in a base64 encoded format. This will be done in a corresponding PR on the frontend.
This change will let logout accept the serviceAuth as part of the wrapper args and send it in an Authorization header.

This should be backward compatible with Tactical IDAM as TIDAM does not check for an Authorization header so whether populated or undefined should still work. On the other hand SIDAM will throw a non-breaking error back to the service if invalid or incorrect.