### PR TITLE
Do base64 encoding in the wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/div-idam-express-middleware",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "description": "Express middleware for IDAM integration",
   "license": "MIT",
   "main": "index.js",

--- a/wrapper/getServiceAuth.js
+++ b/wrapper/getServiceAuth.js
@@ -1,0 +1,9 @@
+const getServiceAuth = (args = {}) => {
+  if (!args.idamClientID || !args.idamSecret) {
+    throw new Error('ClientID or Secret is undefined');
+  }
+  return Buffer.from(`${args.idamClientID}:${args.idamSecret}`)
+    .toString('base64');
+};
+
+module.exports = getServiceAuth;

--- a/wrapper/getServiceAuth.test.js
+++ b/wrapper/getServiceAuth.test.js
@@ -1,0 +1,39 @@
+const { expect } = require('chai');
+const getServiceAuth = require('./getServiceAuth');
+
+describe('getServiceAuth', () => {
+  it('should return a properly encoded base64 string with a client id and secret', () => {
+    const args = {
+      idamClientID: 'clientId',
+      idamSecret: 'secret'
+    };
+
+    const base64String = Buffer.from(`${args.idamClientID}:${args.idamSecret}`).toString('base64');
+
+    expect(getServiceAuth(args)).to.equal(base64String);
+  });
+
+  it('should throw an error when no client id and secret exists', () => {
+    const args = {};
+
+    expect(() => {
+      getServiceAuth(args);
+    }).to.throw('ClientID or Secret is undefined');
+  });
+
+  it('should throw an error when no client id exists', () => {
+    const args = { idamSecret: 'secret' };
+
+    expect(() => {
+      getServiceAuth(args);
+    }).to.throw('ClientID or Secret is undefined');
+  });
+
+  it('should throw an error when no secret exists', () => {
+    const args = { idamClientID: 'clientId' };
+
+    expect(() => {
+      getServiceAuth(args);
+    }).to.throw('ClientID or Secret is undefined');
+  });
+});

--- a/wrapper/index.js
+++ b/wrapper/index.js
@@ -1,6 +1,7 @@
 const loginUrl = require('./loginUrl');
 const userDetails = require('./getUserDetails');
 const accessToken = require('./accessToken');
+const serviceAuth = require('./getServiceAuth');
 
 const setup = (args = {}) => {
   const getIdamLoginUrl = options => {
@@ -20,7 +21,7 @@ const setup = (args = {}) => {
   };
 
   const getServiceAuth = () => {
-    return args.serviceAuth;
+    return serviceAuth(args);
   };
 
   return {


### PR DESCRIPTION
Realised that our frontend actually passes the following args as part of the IDAM setup:
```
const idamArgs = {
  redirectUri: landingPageUrl,
  indexUrl: confIdam.indexUrl,
  idamApiUrl: confIdam.idamApiUrl,
  idamLoginUrl: confIdam.idamLoginUrl,
  idamSecret: confIdam.idamSecret,
  idamClientID: confIdam.idamClientID
};
```

The initial idea was to do the encoding in the frontend and pass the encoded string to idam-express-middleware but if we are already taking in the two parameters required for the encoding (ClientId and Secret) then we can mandate that requirement and instead do everything in the wrapper.

That way we only need to update the repos package.json dependency version instead of implementing a base64 encoder in those.