### PR TITLE
Cookie on landing page

### DIFF
--- a/services/idamExpressLanding.js
+++ b/services/idamExpressLanding.js
@@ -36,6 +36,9 @@ const idamExpressLanding = (args = {}) => {
       })
       .then(response => {
         cookies.set(res, tokenCookieName, response.access_token, args.hostName);
+        // set cookie on req so it can be used during this request
+        req.cookies = req.cookies || {};
+        req.cookies[tokenCookieName] = response.access_token;
         return idamFunctions
           .getUserDetails(response.access_token, args);
       })

--- a/services/idamExpressLanding.test.js
+++ b/services/idamExpressLanding.test.js
@@ -72,7 +72,7 @@ describe('idamExpressLanding', () => {
         req.query.code = 'code';
         req.cookies[config.stateCookieName] = 'state';
 
-        const response = { body: { access_token: 'access_token' } };
+        const response = { access_token: 'access_token' };
         getAccessToken.resolves(response);
         getUserDetails.resolves(userDetails);
 
@@ -81,6 +81,7 @@ describe('idamExpressLanding', () => {
         expect(getAccessToken.callCount).to.equal(1);
         expect(getUserDetails.callCount).to.equal(1);
         expect(res.cookie.callCount).to.equal(1);
+        expect(req.cookies['__auth-token']).to.eql(response.access_token);
         expect(next.callCount).to.equal(1);
         expect(req.idam.userDetails).to.equal(userDetails);
       });


### PR DESCRIPTION
Add token cookie to req object immediately. This allows applications to use without waiting for response