### PR TITLE
Accept auth token from query

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,7 +30,7 @@
     "mocha/no-exclusive-tests": "error",
     "max-len": [
       "error", {
-        "code": 80,
+        "code": 100,
         "ignoreStrings": true,
         "ignoreTemplateLiterals": true,
         "ignoreComments": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/div-idam-express-middleware",
-  "version": "6.2.2",
+  "version": "6.3.2",
   "description": "Express middleware for IDAM integration",
   "license": "MIT",
   "main": "index.js",

--- a/services/idamExpressLanding.js
+++ b/services/idamExpressLanding.js
@@ -12,7 +12,7 @@ const idamExpressLanding = (args = {}) => {
   const stateCookieName = args.stateCookieName || config.stateCookieName;
 
   return (req, res, next) => {
-    const authToken = req.query[tokenCookieName];
+    const authToken = req.headers[tokenCookieName];
     const code = req.query.code;
 
     // If no code then landing page was not reached through IDAM

--- a/services/idamExpressLanding.js
+++ b/services/idamExpressLanding.js
@@ -12,7 +12,7 @@ const idamExpressLanding = (args = {}) => {
   const stateCookieName = args.stateCookieName || config.stateCookieName;
 
   return (req, res, next) => {
-    const authToken = req.headers[tokenCookieName];
+    const authToken = req.query[tokenCookieName];
     const code = req.query.code;
 
     // If no code then landing page was not reached through IDAM

--- a/services/idamExpressLanding.js
+++ b/services/idamExpressLanding.js
@@ -12,44 +12,61 @@ const idamExpressLanding = (args = {}) => {
   const stateCookieName = args.stateCookieName || config.stateCookieName;
 
   return (req, res, next) => {
-    const state = cookies.get(req, stateCookieName);
-    if (!state) {
-      logger.error('State cookie does not exist');
-      res.redirect(args.indexUrl);
-      return;
-    }
-
-    const code = req.query.code;
-    if (!code) {
-      logger.error('Code has not been set on the query string');
-      res.redirect(args.indexUrl);
-      return;
-    }
-
-    cookies.remove(res, stateCookieName);
-
-    idamFunctions
-      .getAccessToken({
-        code,
-        state,
-        redirect_uri: args.redirectUri
-      })
-      .then(response => {
-        cookies.set(res, tokenCookieName, response.access_token, args.hostName);
-        // set cookie on req so it can be used during this request
-        req.cookies = req.cookies || {};
-        req.cookies[tokenCookieName] = response.access_token;
-        return idamFunctions
-          .getUserDetails(response.access_token, args);
-      })
-      .then(userDetails => {
-        req.idam = { userDetails };
-        next();
-      })
-      .catch(error => {
-        logger.error(`An error occurred when authenticating the user: ${error}`);
+    const authToken = req.query[tokenCookieName];
+    if (authToken) {
+      cookies.set(res, tokenCookieName, authToken, args.hostName);
+      // set cookie on req so it can be used during this request
+      req.cookies = req.cookies || {};
+      req.cookies[tokenCookieName] = authToken;
+      idamFunctions.getUserDetails(authToken, args)
+        .then(userDetails => {
+          req.idam = { userDetails };
+          next();
+        })
+        .catch(error => {
+          logger.error(`An error occurred when authenticating the user: ${error}`);
+          res.redirect(args.indexUrl);
+        });
+    } else {
+      const state = cookies.get(req, stateCookieName);
+      if (!state) {
+        logger.error('State cookie does not exist');
         res.redirect(args.indexUrl);
-      });
+        return;
+      }
+
+      const code = req.query.code;
+      if (!code) {
+        logger.error('Code has not been set on the query string');
+        res.redirect(args.indexUrl);
+        return;
+      }
+
+      cookies.remove(res, stateCookieName);
+
+      idamFunctions
+        .getAccessToken({
+          code,
+          state,
+          redirect_uri: args.redirectUri
+        })
+        .then(response => {
+          cookies.set(res, tokenCookieName, response.access_token, args.hostName);
+          // set cookie on req so it can be used during this request
+          req.cookies = req.cookies || {};
+          req.cookies[tokenCookieName] = response.access_token;
+          return idamFunctions
+            .getUserDetails(response.access_token, args);
+        })
+        .then(userDetails => {
+          req.idam = { userDetails };
+          next();
+        })
+        .catch(error => {
+          logger.error(`An error occurred when authenticating the user: ${error}`);
+          res.redirect(args.indexUrl);
+        });
+    }
   };
 };
 

--- a/services/idamExpressLanding.test.js
+++ b/services/idamExpressLanding.test.js
@@ -26,7 +26,8 @@ describe('idamExpressLanding', () => {
     beforeEach(() => {
       req = {
         cookies: {},
-        query: []
+        query: [],
+        headers: {}
       };
       res = {
         redirect: sinon.stub(),
@@ -101,7 +102,7 @@ describe('idamExpressLanding', () => {
 
       context('authToken query', () => {
         beforeEach(() => {
-          req.query[config.tokenCookieName] = 'authToken';
+          req.headers[config.tokenCookieName] = 'authToken';
         });
 
         it('should set the authToken cookie with the query value', () => {

--- a/services/idamExpressLanding.test.js
+++ b/services/idamExpressLanding.test.js
@@ -99,27 +99,27 @@ describe('idamExpressLanding', () => {
         expect(next.callCount).to.equal(0);
       });
 
-      context('authToken query', () => {  
+      context('authToken query', () => {
         beforeEach(() => {
           req.query[config.tokenCookieName] = 'authToken';
         });
-  
+
         it('should set the authToken cookie with the query value', () => {
           getUserDetails.resolves(userDetails);
-  
+
           idamExpressLanding(req, res, next);
-  
+
           expect(getUserDetails.callCount).to.equal(1);
           expect(res.cookie.callCount).to.equal(1);
           expect(next.callCount).to.equal(1);
           expect(req.cookies[config.tokenCookieName]).to.equal('authToken');
         });
-  
+
         it('should redirect if authToken is invalid', () => {
           getUserDetails.rejects();
-  
+
           idamExpressLanding(req, res, next);
-  
+
           expect(res.redirect.callCount).to.equal(1);
           expect(res.redirect.calledWith('/')).to.equal(true);
           expect(next.callCount).to.equal(0);

--- a/services/idamExpressLanding.test.js
+++ b/services/idamExpressLanding.test.js
@@ -98,6 +98,33 @@ describe('idamExpressLanding', () => {
         expect(res.redirect.calledWith('/')).to.equal(true);
         expect(next.callCount).to.equal(0);
       });
+
+      context('authToken query', () => {  
+        beforeEach(() => {
+          req.query[config.tokenCookieName] = 'authToken';
+        });
+  
+        it('should set the authToken cookie with the query value', () => {
+          getUserDetails.resolves(userDetails);
+  
+          idamExpressLanding(req, res, next);
+  
+          expect(getUserDetails.callCount).to.equal(1);
+          expect(res.cookie.callCount).to.equal(1);
+          expect(next.callCount).to.equal(1);
+          expect(req.cookies[config.tokenCookieName]).to.equal('authToken');
+        });
+  
+        it('should redirect if authToken is invalid', () => {
+          getUserDetails.rejects();
+  
+          idamExpressLanding(req, res, next);
+  
+          expect(res.redirect.callCount).to.equal(1);
+          expect(res.redirect.calledWith('/')).to.equal(true);
+          expect(next.callCount).to.equal(0);
+        });
+      });
     }
 
     it('redirects if no state exists', () => {

--- a/services/idamExpressLanding.test.js
+++ b/services/idamExpressLanding.test.js
@@ -26,8 +26,7 @@ describe('idamExpressLanding', () => {
     beforeEach(() => {
       req = {
         cookies: {},
-        query: [],
-        headers: {}
+        query: []
       };
       res = {
         redirect: sinon.stub(),
@@ -102,7 +101,7 @@ describe('idamExpressLanding', () => {
 
       context('authToken query', () => {
         beforeEach(() => {
-          req.headers[config.tokenCookieName] = 'authToken';
+          req.query[config.tokenCookieName] = 'authToken';
         });
 
         it('should set the authToken cookie with the query value', () => {


### PR DESCRIPTION
On the IDAM landing page (/authenticated), if we don't have a code query (so not redirected from IDAM) but we have an authToken query then we set the authCookie using that.

This is because one domain can not set cookies on another domain for security reasons, and to use wildcard domains we would have to hardcode in the values.

Let me know if there is a better way to maintaining the auth token cookie.