### PR TITLE
Handle wrong jwt error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/div-idam-express-middleware",
-  "version": "6.3.4",
+  "version": "6.3.5",
   "description": "Express middleware for IDAM integration",
   "license": "MIT",
   "main": "index.js",
@@ -14,7 +14,7 @@
     "sonar-scanner": "node_modules/sonar-scanner/bin/sonar-scanner"
   },
   "dependencies": {
-    "@hmcts/nodejs-logging": "^2.2.0",
+    "@hmcts/nodejs-logging": "^3.0.0",
     "jwt-decode": "^2.2.0",
     "request": "^2.83.0",
     "request-promise-native": "^1.0.5",

--- a/services/idamExpressLanding.js
+++ b/services/idamExpressLanding.js
@@ -37,7 +37,7 @@ const idamExpressLanding = (args = {}) => {
               res.redirect(args.indexUrl);
             });
         } catch (error) {
-          next(); 
+          next();
         }
       } else {
         logger.error('Code has not been set on the query string');

--- a/services/idamExpressLanding.js
+++ b/services/idamExpressLanding.js
@@ -19,22 +19,26 @@ const idamExpressLanding = (args = {}) => {
     // If no code then landing page was not reached through IDAM
     if (!code) {
       if (authToken) {
-        // validate authToken. Throws error if invalid
-        jwtDecode(authToken);
+        try {
+          // validate authToken, do nothing if error
+          jwtDecode(authToken);
 
-        cookies.set(res, tokenCookieName, authToken, args.hostName);
-        // set cookie on req so it can be used during this request
-        req.cookies = req.cookies || {};
-        req.cookies[tokenCookieName] = authToken;
-        idamFunctions.getUserDetails(authToken, args)
-          .then(userDetails => {
-            req.idam = { userDetails };
-            next();
-          })
-          .catch(error => {
-            logger.error(`An error occurred when authenticating the user: ${error}`);
-            res.redirect(args.indexUrl);
-          });
+          cookies.set(res, tokenCookieName, authToken, args.hostName);
+          // set cookie on req so it can be used during this request
+          req.cookies = req.cookies || {};
+          req.cookies[tokenCookieName] = authToken;
+          idamFunctions.getUserDetails(authToken, args)
+            .then(userDetails => {
+              req.idam = { userDetails };
+              next();
+            })
+            .catch(error => {
+              logger.error(`An error occurred when authenticating the user: ${error}`);
+              res.redirect(args.indexUrl);
+            });
+        } catch (error) {
+          next(); 
+        }
       } else {
         logger.error('Code has not been set on the query string');
         res.redirect(args.indexUrl);

--- a/services/idamExpressLanding.test.js
+++ b/services/idamExpressLanding.test.js
@@ -117,17 +117,13 @@ describe('idamExpressLanding', () => {
           expect(req.cookies[config.tokenCookieName]).to.equal(testToken);
         });
 
-        it('should throw error is authToken is invalid', () => {
+        it('should do nothing but call next when authToken is invalid', () => {
           req.query[config.tokenCookieName] = 'invalidAuthToken';
 
-          try {
-            idamExpressLanding(req, res, next);
-          } catch (error) {
-            expect(typeof error).to.not.equal('undefined');
-          }
+          idamExpressLanding(req, res, next);
 
           expect(res.redirect.callCount).to.equal(0);
-          expect(next.callCount).to.equal(0);
+          expect(next.callCount).to.equal(1);
         });
 
         it('should redirect if authToken is unauthorised', () => {


### PR DESCRIPTION
Rather than send the user to an error page, just don't set an auth token cookie if the auth query is invalid.